### PR TITLE
Fix renderPath method

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,7 +78,7 @@ $(document).ready(function() {
     next.push(tagSquare(x-2,y+1,val,steps));
 
     next.forEach((sq) => {
-      if (sq && sq.x) renderPath(sq.x, sq.y, sq.val, sq.steps);
+      if (sq) renderPath(sq.x, sq.y, sq.val, sq.steps);
     });
   }
 


### PR DESCRIPTION
There is a condition preventing the renderPath method being recursively called with parameter x set to 0, resulting in missing moves coming from the eighth row of the board (e.g. when the knight is on h7, g6 is shown as four moves away instead of two, due to the move from f8 being ignored). I think the most straightforward fix is removing the condition as it doesn't seem necessary.

Btw, great job on the visualization @hookdump . I was interested in doing something like this thinking it would be helpful, and it turns out it totally is! Thank you for getting it right 👌