### PR TITLE
Introduced the ability to switch between pieces and accurately give information about their movement.

### DIFF
--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ $(document).ready(function() {
   }
 
   function clickHandler(event) {
-    var type = 'K'
+    var type = 'N'
     var target = $(event.currentTarget);
     var id = target.find(".identifier").text();
     if (event.which == 1) {

--- a/main.js
+++ b/main.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
 		next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
 	}
 	if ('KBQ'.includes(type)) {
-		for (var i=0; i<=move; i++) {
+		for (var i=1; i<=move; i++) {
 			next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
 			next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
 			next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
@@ -94,7 +94,7 @@ $(document).ready(function() {
 		}
 	}
 	if ('KRQ'.includes(type)) {
-		for (var i=0; i<=move; i++) {
+		for (var i=1; i<=move; i++) {
 			next.push(tagSquare(type,x,y-i,val,steps,color=color));
 			next.push(tagSquare(type,x,y+i,val,steps,color=color));
 			next.push(tagSquare(type,x-i,y,val,steps,color=color));

--- a/main.js
+++ b/main.js
@@ -93,7 +93,7 @@ $(document).ready(function() {
         next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
       }
     }
-    if ('KRQ'.includes(type)) { // if type is a King, Bishop or Queen
+    if ('KRQ'.includes(type)) { // if type is a King, Rook or Queen
       for (var i=1; i<=move; i++) { // push files and colomns
         next.push(tagSquare(type,x,y-i,val,steps,color=color));
         next.push(tagSquare(type,x,y+i,val,steps,color=color));

--- a/main.js
+++ b/main.js
@@ -72,59 +72,59 @@ $(document).ready(function() {
     var next = [];
     var move = 7;
 
-    if ('K'.includes(type)) {
-      move = 1;
+    if ('K'.includes(type)) { // if type is King
+        move = 1;
     }
-    if ('N'.includes(type)) {
-		next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
-		next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
-		next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
-		next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
-		next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
-		next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
-		next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
-		next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
-	}
-	if ('KBQ'.includes(type)) {
-		for (var i=1; i<=move; i++) {
-			next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
-			next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
-			next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
-			next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
-		}
-	}
-	if ('KRQ'.includes(type)) {
-		for (var i=1; i<=move; i++) {
-			next.push(tagSquare(type,x,y-i,val,steps,color=color));
-			next.push(tagSquare(type,x,y+i,val,steps,color=color));
-			next.push(tagSquare(type,x-i,y,val,steps,color=color));
-			next.push(tagSquare(type,x+i,y,val,steps,color=color));
-		}
-	}
-	if ('P'.includes(type)) {
+    if ('N'.includes(type)) { // if type is a Knight
+	next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
+	next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
+	next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
+	next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
+	next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
+	next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
+	next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
+	next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
+    }
+    if ('KBQ'.includes(type)) { // if type is a King, Bishop, or Queen
+        for (var i=1; i<=move; i++) { // push diagonals
+            next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
+            next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
+            next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
+            next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
+        }
+    }
+    if ('KRQ'.includes(type)) { // if type is a King, Bishop or Queen
+        for (var i=1; i<=move; i++) { // push files and colomns
+            next.push(tagSquare(type,x,y-i,val,steps,color=color));
+            next.push(tagSquare(type,x,y+i,val,steps,color=color));
+            next.push(tagSquare(type,x-i,y,val,steps,color=color));
+            next.push(tagSquare(type,x+i,y,val,steps,color=color));
+        }
+    }
+    if ('P'.includes(type)) { // if type is a Pawn
+        if (color == 0) { // if white
+            move = 1
+            if (x > 5) { // on the first movement
+                move = 2 // allow double movement
 
-	  if (color == 0) {
-	    move = 1
-	    if (x > 5) {
-	     move = 2
-	     next.push(tagSquare(type,x-1,y,val,steps,color=color));
-	    }
-	  } else if (color == 1) {
-	    move = -1
-	    if (x < 2) {
-	      move = -2
-	      next.push(tagSquare(type,x+1,y,val,steps,color=color));
-	    }
-	  }
-	  next.push(tagSquare(type,x-move,y,val,steps,color=color));
-	  
+                next.push(tagSquare(type,x-1,y,val,steps,color=color));  // Puts a 1 directly in front of pawn.
+            }
+        } else if (color == 1) { // if black
+            move = -1
+            if (x < 2) { // on the first movement
+                move = -2 // allow double movement
+
+                next.push(tagSquare(type,x+1,y,val,steps,color=color)); // Puts a 1 directly in front of pawn.
+            }
 	}
+	    next.push(tagSquare(type,x-move,y,val,steps,color=color)); // Follows the double-step line.
+    }
     next.forEach((sq) => {
-      if (sq) renderPath(sq.type, sq.x, sq.y, sq.val, sq.steps, color=sq.color);
+        if (sq) renderPath(sq.type, sq.x, sq.y, sq.val, sq.steps, color=sq.color);
     });
   }
 
-  function refresh(type, sq, color=0) {
+  function refresh(type, sq, color=0) { //Change color here. 0 for white 1 for black. Useful for pawns.
     console.log('REFRESH', sq);
     currentPos = sq;
     initBoard();
@@ -132,8 +132,8 @@ $(document).ready(function() {
     var pos = index[sq];
     var x = pos[0];
     var y = pos[1];
-    renderPath(type, x, y, 1, 6,color=color);
-    var sprite = ['K','Q', 'B', 'N', 'R', 'P'].indexOf(type) + 1 + color * 6
+    renderPath(type, x, y, 1, 6, color=color);
+    var sprite = ['-', 'K', 'Q', 'B', 'N', 'R', 'P'].indexOf(type) + color * 6
     $('.piece').css("background-image", "url('img/sprites_" + sprite.toString().padStart(2, '0') + ".png')");
     $("." + sq).find(".txt").addClass("hide").html("&nbsp;");
     console.log(tagged);
@@ -150,7 +150,7 @@ $(document).ready(function() {
   }
 
   function clickHandler(event) {
-    var type = 'N'
+    var type = 'N' // Change pieces here 'K', 'Q', 'B', 'N', 'R', and 'P' are supported.
     var target = $(event.currentTarget);
     var id = target.find(".identifier").text();
     if (event.which == 1) {

--- a/main.js
+++ b/main.js
@@ -76,14 +76,14 @@ $(document).ready(function() {
       move = 1;
     }
     if ('N'.includes(type)) { // if type is a Knight
-	  next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
-	  next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
-	  next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
-	  next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
-	  next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
-	  next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
-	  next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
-	  next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
+      next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
+      next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
+      next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
+      next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
+      next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
+      next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
+      next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
+      next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
     }
     if ('KBQ'.includes(type)) { // if type is a King, Bishop, or Queen
       for (var i=1; i<=move; i++) { // push diagonals

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ $(document).ready(function() {
     $("." + square).find(".txt").html("&nbsp;");
   };
 
-  var tagSquare = (x, y, val, steps) => {
+  var tagSquare = (type, x, y, val, steps, color=0) => {
     var sq = null;
     if (x >= 0 && x < 8 && y >= 0 && y < 8) {
       sq = board[x][y];
@@ -62,63 +62,104 @@ $(document).ready(function() {
         $("." + sq).addClass("heat-" + val);
         tagged[sq] = val;
         if (steps > 0) {
-          return {x: x, y: y, val: ++val, steps: --steps};
+          return {type: type, x: x, y: y, val: ++val, steps: --steps, color: color};
         }
       }
     }
   }
 
-  var renderPath = (x, y, val, steps) => {
+  var renderPath = (type, x, y, val, steps, color=0) => {
     var next = [];
+    var move = 7;
 
-    // knight!
-    next.push(tagSquare(x+1,y-2,val,steps));
-    next.push(tagSquare(x+1,y+2,val,steps));
-    next.push(tagSquare(x-1,y-2,val,steps));
-    next.push(tagSquare(x-1,y+2,val,steps));
-    next.push(tagSquare(x+2,y-1,val,steps));
-    next.push(tagSquare(x+2,y+1,val,steps));
-    next.push(tagSquare(x-2,y-1,val,steps));
-    next.push(tagSquare(x-2,y+1,val,steps));
+    if ('K'.includes(type)) {
+      move = 1;
+    }
+    if ('N'.includes(type)) {
+		next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
+		next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
+		next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
+		next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
+		next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
+		next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
+		next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
+		next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
+	}
+	if ('KBQ'.includes(type)) {
+		for (var i=0; i<=move; i++) {
+			next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
+			next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
+			next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
+			next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
+		}
+	}
+	if ('KRQ'.includes(type)) {
+		for (var i=0; i<=move; i++) {
+			next.push(tagSquare(type,x,y-i,val,steps,color=color));
+			next.push(tagSquare(type,x,y+i,val,steps,color=color));
+			next.push(tagSquare(type,x-i,y,val,steps,color=color));
+			next.push(tagSquare(type,x+i,y,val,steps,color=color));
+		}
+	}
+	if ('P'.includes(type)) {
 
+	  if (color == 0) {
+	    move = 1
+	    if (x > 5) {
+	     move = 2
+	     next.push(tagSquare(type,x-1,y,val,steps,color=color));
+	    }
+	  } else if (color == 1) {
+	    move = -1
+	    if (x < 2) {
+	      move = -2
+	      next.push(tagSquare(type,x+1,y,val,steps,color=color));
+	    }
+	  }
+	  next.push(tagSquare(type,x-move,y,val,steps,color=color));
+	  
+	}
     next.forEach((sq) => {
-      if (sq) renderPath(sq.x, sq.y, sq.val, sq.steps);
+      if (sq) renderPath(sq.type, sq.x, sq.y, sq.val, sq.steps, color=sq.color);
     });
   }
 
-  function refresh(sq) {
+  function refresh(type, sq, color=0) {
     console.log('REFRESH', sq);
     currentPos = sq;
     initBoard();
-    initPiece('N', sq);
+    initPiece(type, sq);
     var pos = index[sq];
     var x = pos[0];
     var y = pos[1];
-    renderPath(x, y, 1, 5);
+    renderPath(type, x, y, 1, 6,color=color);
+    var sprite = ['K','Q', 'B', 'N', 'R', 'P'].indexOf(type) + 1 + color * 6
+    $('.piece').css("background-image", "url('img/sprites_" + sprite.toString().padStart(2, '0') + ".png')");
     $("." + sq).find(".txt").addClass("hide").html("&nbsp;");
     console.log(tagged);
   }
 
-  function toggleBlock(sq) {
+  function toggleBlock(type, sq) {
     if (blocked[sq]) {
       blocked[sq] = false;
     } else {
       blocked[sq] = true;
     }
     console.log("BLOCKED", blocked);
-    refresh(currentPos);
+    refresh(type, currentPos);
   }
 
   function clickHandler(event) {
+    var type = 'K'
     var target = $(event.currentTarget);
     var id = target.find(".identifier").text();
     if (event.which == 1) {
-      refresh(id);
+      refresh(type, id);
     } else {
       event.preventDefault();
-      toggleBlock(id);
+      toggleBlock(type, id);
     }
   }
 
-  refresh('g1');
+  refresh('N', 'g1');
 });

--- a/main.js
+++ b/main.js
@@ -72,55 +72,57 @@ $(document).ready(function() {
     var next = [];
     var move = 7;
 
-    if ('K'.includes(type)) { // if type is King
-        move = 1;
+    if ('K'.includes(type)) { // if type is a King
+      move = 1;
     }
     if ('N'.includes(type)) { // if type is a Knight
-	next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
-	next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
-	next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
-	next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
-	next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
-	next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
-	next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
-	next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
+	  next.push(tagSquare(type,x+1,y-2,val,steps,color=color));
+	  next.push(tagSquare(type,x+1,y+2,val,steps,color=color));
+	  next.push(tagSquare(type,x-1,y-2,val,steps,color=color));
+	  next.push(tagSquare(type,x-1,y+2,val,steps,color=color));
+	  next.push(tagSquare(type,x+2,y-1,val,steps,color=color));
+	  next.push(tagSquare(type,x+2,y+1,val,steps,color=color));
+	  next.push(tagSquare(type,x-2,y-1,val,steps,color=color));
+	  next.push(tagSquare(type,x-2,y+1,val,steps,color=color));
     }
     if ('KBQ'.includes(type)) { // if type is a King, Bishop, or Queen
-        for (var i=1; i<=move; i++) { // push diagonals
-            next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
-            next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
-            next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
-            next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
-        }
+      for (var i=1; i<=move; i++) { // push diagonals
+        next.push(tagSquare(type,x-i,y-i,val,steps,color=color));
+        next.push(tagSquare(type,x+i,y+i,val,steps,color=color));
+        next.push(tagSquare(type,x-i,y+i,val,steps,color=color));
+        next.push(tagSquare(type,x+i,y-i,val,steps,color=color));
+      }
     }
     if ('KRQ'.includes(type)) { // if type is a King, Bishop or Queen
-        for (var i=1; i<=move; i++) { // push files and colomns
-            next.push(tagSquare(type,x,y-i,val,steps,color=color));
-            next.push(tagSquare(type,x,y+i,val,steps,color=color));
-            next.push(tagSquare(type,x-i,y,val,steps,color=color));
-            next.push(tagSquare(type,x+i,y,val,steps,color=color));
-        }
+      for (var i=1; i<=move; i++) { // push files and colomns
+        next.push(tagSquare(type,x,y-i,val,steps,color=color));
+        next.push(tagSquare(type,x,y+i,val,steps,color=color));
+        next.push(tagSquare(type,x-i,y,val,steps,color=color));
+        next.push(tagSquare(type,x+i,y,val,steps,color=color));
+      }
     }
     if ('P'.includes(type)) { // if type is a Pawn
-        if (color == 0) { // if white
-            move = 1
-            if (x > 5) { // on the first movement
-                move = 2 // allow double movement
+      if (color == 0) { // if white
+        move = 1
+        if (x > 5) { // on the first movement
+          move = 2 // allow double movement
 
-                next.push(tagSquare(type,x-1,y,val,steps,color=color));  // Puts a 1 directly in front of pawn.
-            }
-        } else if (color == 1) { // if black
-            move = -1
-            if (x < 2) { // on the first movement
-                move = -2 // allow double movement
+          next.push(tagSquare(type,x-1,y,val,steps,color=color));  // Puts a 1 directly in front of pawn.
+        }
+      } else if (color == 1) { // if black
+        move = -1
+          if (x < 2) { // on the first movement
+            move = -2 // allow double movement
 
-                next.push(tagSquare(type,x+1,y,val,steps,color=color)); // Puts a 1 directly in front of pawn.
-            }
-	}
-	    next.push(tagSquare(type,x-move,y,val,steps,color=color)); // Follows the double-step line.
+            next.push(tagSquare(type,x+1,y,val,steps,color=color)); // Puts a 1 directly in front of pawn.
+          }
+      }
+
+      next.push(tagSquare(type,x-move,y,val,steps,color=color)); // Follows the double-step line.
     }
-    next.forEach((sq) => {
-        if (sq) renderPath(sq.type, sq.x, sq.y, sq.val, sq.steps, color=sq.color);
+
+    next.forEach((sq) => { // Recursively calls renderPath if there are viable squares in next to move to.
+      if (sq) renderPath(sq.type, sq.x, sq.y, sq.val, sq.steps, color=sq.color);
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,7 @@ body {
   opacity: 1;
 }
 
+.heat-7 { background-color: rgb(90, 0, 0) !important; }
 .heat-6 { background-color: rgb(150, 0, 0) !important; }
 .heat-5 { background-color: rgb(255, 50, 0) !important; }
 .heat-4 { background-color: rgb(255, 150, 0) !important; }


### PR DESCRIPTION
1. Updated the JS so that it can support any type of piece. (On line 153 in main.js change `var type = 'N'` to `var type = 'Q'` to experiment.)

2. Added support for both white and black pieces which can be changed by sending color = 0 for white or color = 1 for black as an optional parameter to refresh, renderPath, and tagSquare, that defaults to white.

Supported piece types are 'K','Q', 'B', 'N', 'R', and 'P' representing King, Queen, Bishop, kNight, Rook, and Pawn respectively.